### PR TITLE
Improve the help message for install command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,10 @@ enum SubCommand {
         name: String, // holds the project name.
     },
 
-    /// Install packages from `pyproject.toml`, or ones specified
+    /** Install packages from `pyproject.toml`, `pyflow.lock`, or speficied ones. Example:
+
+    `pyflow install`: sync your installation with `pyproject.toml`, or `pyflow.lock` if it exists.
+    `pyflow install numpy scipy`: install `numpy` and `scipy`.*/
     #[structopt(name = "install")]
     Install {
         #[structopt(name = "packages")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,18 +51,11 @@ enum SubCommand {
     },
 
     /// Install packages from `pyproject.toml`, or ones specified
-    #[structopt(
-        name = "install",
-        help = "
-Install packages from `pyproject.toml`, `pyflow.lock`, or speficied ones. Example:
-
-`pyflow install`: sync your installation with `pyproject.toml`, or `pyflow.lock` if it exists.
-`pyflow install numpy scipy`: install `numpy` and `scipy`.
-"
-    )]
+    #[structopt(name = "install")]
     Install {
         #[structopt(name = "packages")]
         packages: Vec<String>,
+        /// Save package to your dev-dependencies section
         #[structopt(short, long)]
         dev: bool,
     },


### PR DESCRIPTION
### Before(Current)

```
$ pyflow help install

Install packages from `pyproject.toml`, `pyflow.lock`, or speficied ones. Example:

`pyflow install`: sync your installation with `pyproject.toml`, or `pyflow.lock` if it exists.
`pyflow install numpy scipy`: install `numpy` and `scipy`.
```

This description has no information about options or arguments. I changed it to display such information like any other command.

### After

```
$ pyflow help install
pyflow-install 0.1.9
Install packages from `pyproject.toml`, or ones specified

USAGE:
    pyflow install [FLAGS] [packages]...

FLAGS:
    -d, --dev        Save package to your dev-dependencies section
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <packages>...    
```

