### PR TITLE
replace `-` in package directory name when using new command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -549,8 +549,8 @@ impl Config {
 /// Create a template directory for a python project.
 pub fn new(name: &str) -> Result<(), Box<dyn Error>> {
     if !PathBuf::from(name).exists() {
-        fs::create_dir_all(&format!("{}/{}", name, name))?;
-        fs::File::create(&format!("{}/{}/__init__.py", name, name))?;
+        fs::create_dir_all(&format!("{}/{}", name, name.replace("-", "_")))?;
+        fs::File::create(&format!("{}/{}/__init__.py", name, name.replace("-", "_")))?;
         fs::File::create(&format!("{}/README.md", name))?;
         fs::File::create(&format!("{}/LICENSE", name))?;
         fs::File::create(&format!("{}/.gitignore", name))?;


### PR DESCRIPTION
When `pyflow new foo-bar` is executed, pyflow creates `foo-bar/foo-bar/__init__.py`. But python package name are not used `-`. We use `_` instead. So pyflow should create `foo-bar/foo_bar/__init__.py`

cf. `poetry new foo-bar` creates `foo-bar/foo_bar/__init__.py`