### PR TITLE
Fixed a typo

### DIFF
--- a/src/dep_types.rs
+++ b/src/dep_types.rs
@@ -48,7 +48,7 @@ impl fmt::Display for DependencyError {
 impl From<num::ParseIntError> for DependencyError {
     fn from(_: num::ParseIntError) -> Self {
         Self {
-            details: "Pare int error".into(),
+            details: "Parse int error".into(),
         }
     }
 }


### PR DESCRIPTION
I fixed a typo "Pare" to "Parse" in error message.