### PR TITLE
Update comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ These tools have different scopes and purposes:
 | **Manages Python installations** | | | | ✓ | | ✓ | ✓ |
 | **Py-environment-agnostic** | | | | ✓ | | ✓ | ✓ |
 | **Included with Python** | ✓ | | | | | | |
-| **Stores deps with project** | | | | | ✓ | | ✓|
+| **Stores deps with project** | | |✓| | ✓ | | ✓|
 | **Requires changing session state** | ✓ | | | ✓ | | | |
 | **Clean build/publish flow** | | | ✓ | | | | ✓ |
 | **Supports old Python versions** | with `virtualenv` | ✓ | ✓ | ✓ | ✓ | ✓ | |


### PR DESCRIPTION
`poetry` also stores dependencies with the project, although this must be configured
globally or locally `poetry config virtualenvs.in-project true --local`.

See https://python-poetry.org/docs/configuration/#virtualenvsin-project-boolean.