### PR TITLE
Add support for stdio in Python code executed by python command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::{error::Error, fmt};
 use std::{
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
 };
 
 #[derive(Debug)]
@@ -110,8 +110,12 @@ pub fn run_python(
     args: &[String],
 ) -> Result<(), Box<dyn Error>> {
     util::set_pythonpath(lib_paths);
-    let output = Command::new(bin_path.join("python")).args(args).output()?;
-    util::check_command_output(&output, "running python");
+    Command::new(bin_path.join("python"))
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .output()?;
     Ok(())
 }
 


### PR DESCRIPTION
Hi,

I found that Python code executed by "python" command cannot use stdio since all stdio are captured in pyflow, and felt that it is a little inconvenient. So, I have added stdio support to the python command so that users can benefit from the standard input and output.

Please forgive me for immediately creating a PR without opening an issue.
I hope I can get some feedback from you.

Many thanks.