### PR TITLE
Fix `pyflow script` crash upon encountering an empty `__requires__`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -927,6 +927,7 @@ fn find_deps_from_script(file_path: &Path) -> Vec<String> {
                             .replace("\"", "")
                             .replace("'", "")
                     })
+                    .filter(|d| !d.is_empty())
                     .collect();
             }
         }


### PR DESCRIPTION
#96

(please be gentle, this is my first one)