### PR TITLE
Make color output optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -44,7 +44,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -283,148 +283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57512e27b69eccc2a3068f2bc962a24186e9e6e2904538aad5885d4877f8c187"
-dependencies = [
- "crossterm_cursor 0.3.1",
- "crossterm_input 0.4.1",
- "crossterm_screen",
- "crossterm_style",
- "crossterm_terminal",
- "crossterm_utils 0.3.1",
-]
-
-[[package]]
-name = "crossterm_cursor"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0b733adeee9b605fec8b1087dc3a17c9849a16c561d5b36f459a2a55135f47"
-dependencies = [
- "crossterm_utils 0.3.1",
- "crossterm_winapi 0.2.1",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_cursor"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48e70d4c84ca3080e43f95bcc69fbea4750dd8ae7e864f54ab2847c9fa842fb"
-dependencies = [
- "crossterm_input 0.5.0",
- "crossterm_utils 0.4.0",
- "crossterm_winapi 0.3.0",
- "lazy_static",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_input"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa27cd549d7967837781e2682aae1adf04c0c4e523099291ad0ffe16ed705c9"
-dependencies = [
- "crossterm_screen",
- "crossterm_utils 0.3.1",
- "crossterm_winapi 0.2.1",
- "libc",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_input"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fafa96a623903f0d9232a13ee43f69334caa770fb412f4319772a9db25952c"
-dependencies = [
- "crossterm_screen",
- "crossterm_utils 0.4.0",
- "crossterm_winapi 0.3.0",
- "lazy_static",
- "libc",
- "mio",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_screen"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08dfba7fade62a6c2c48ad6451e288f15fd9ffa640078fc4b08948e81d19db7"
-dependencies = [
- "crossterm_utils 0.4.0",
- "crossterm_winapi 0.3.0",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_style"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b456402b03be74b9f765c85edf36e34f8292d3839312b458b015e52f1fc81d86"
-dependencies = [
- "crossterm_utils 0.4.0",
- "crossterm_winapi 0.3.0",
- "lazy_static",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_terminal"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f09b946c37159123fa3fd70215e4ac99dbd660a80b3878f4612f1b9ed4bc88"
-dependencies = [
- "crossterm_cursor 0.4.0",
- "crossterm_utils 0.4.0",
- "crossterm_winapi 0.3.0",
- "libc",
-]
-
-[[package]]
-name = "crossterm_utils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b46df236ff59f418afe87b2f19941e050ac205f1f1aa0bdba114b820201477"
-dependencies = [
- "crossterm_winapi 0.2.1",
- "libc",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_utils"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c13047e5f7265fe853d54211dbb9bce57220f62d952d48556299f7a65d564a3"
-dependencies = [
- "crossterm_winapi 0.3.0",
- "lazy_static",
- "libc",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521f4476da2d62ec558221bf3136d834cc08c585b1bcb2c072f89e47b27f138"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df25e92a352488d9b3e0215e4e99402945993026159f98b477047719f16a6530"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "ct-logs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,7 +316,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_users",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -522,7 +380,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -796,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "lock_api"
@@ -920,7 +778,7 @@ checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -967,7 +825,7 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1046,7 +904,7 @@ dependencies = [
 name = "pyflow"
 version = "0.2.9"
 dependencies = [
- "crossterm",
+ "atty",
  "data-encoding",
  "directories",
  "flate2",
@@ -1060,6 +918,7 @@ dependencies = [
  "serde",
  "structopt",
  "tar",
+ "termcolor",
  "toml",
  "xz2",
  "zip",
@@ -1090,7 +949,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1144,7 +1003,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1158,7 +1017,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1272,7 +1131,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1431,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "spin"
@@ -1538,6 +1397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,7 +1431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1761,7 +1629,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec 1.4.0",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -1933,9 +1801,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1954,6 +1822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,7 +1842,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ categories = ["development-tools::build-utils"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossterm = "^0.11.1"
+termcolor = "^1.1"
+atty = "^0.2.14"
 data-encoding = "^2.1.2"
 directories = "^2.0.2"
 flate2 = "1.0.12"

--- a/src/build.rs
+++ b/src/build.rs
@@ -57,7 +57,7 @@ fn cfg_to_setup(cfg: &crate::Config) -> String {
     let cfg = cfg.clone();
 
     let version = match cfg.version {
-        Some(v) => v.to_string2(),
+        Some(v) => v.to_string(),
         None => "".into(),
     };
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,8 +1,8 @@
 use crate::{dep_types::Req, util};
-use crossterm::Color;
 use regex::Regex;
 use std::collections::HashMap;
 use std::{env, fs, path::PathBuf, process::Command};
+use termcolor::Color;
 
 // https://packaging.python.org/tutorials/packaging-projects/
 
@@ -57,7 +57,7 @@ fn cfg_to_setup(cfg: &crate::Config) -> String {
     let cfg = cfg.clone();
 
     let version = match cfg.version {
-        Some(v) => v.to_string(),
+        Some(v) => v.to_string2(),
         None => "".into(),
     };
 

--- a/src/dep_resolution.rs
+++ b/src/dep_resolution.rs
@@ -96,7 +96,7 @@ pub fn get_warehouse_release(
     let data = get_warehouse_data(name)?;
 
     // If there are 0s in the version, and unable to find one, try 1 and 2 digit versions on Pypi.
-    let mut release_data = data.releases.get(&version.to_string2());
+    let mut release_data = data.releases.get(&version.to_string());
     if release_data.is_none() && version.patch == 0 {
         release_data = data.releases.get(&version.to_string_med());
         if release_data.is_none() && version.minor == 0 {
@@ -144,7 +144,7 @@ fn get_req_cache_multiple(
     // parse strings here.
     let mut packages2 = HashMap::new();
     for (name, versions) in packages.iter() {
-        let versions = versions.iter().map(Version::to_string2).collect();
+        let versions = versions.iter().map(Version::to_string).collect();
         packages2.insert(name.to_owned(), versions);
     }
 

--- a/src/dep_resolution.rs
+++ b/src/dep_resolution.rs
@@ -5,11 +5,11 @@ use crate::{
     util,
 };
 
-use crossterm::Color;
 use serde::{Deserialize, Serialize};
 use std::cmp::min;
 use std::collections::HashMap;
 use std::str::FromStr;
+use termcolor::Color;
 
 #[derive(Debug, Deserialize)]
 struct WarehouseInfo {
@@ -478,7 +478,7 @@ fn make_renamed_packs(
              your package may not be published unless this is resolved...",
             name
         ),
-        Color::DarkYellow,
+        Color::Yellow, // Dark
     );
 
     let dep_display: Vec<String> = deps

--- a/src/files.rs
+++ b/src/files.rs
@@ -2,13 +2,13 @@ use crate::{
     dep_types::{Req, Version},
     util, Config,
 };
-use crossterm::Color;
 use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+use termcolor::Color;
 
 #[derive(Debug, Deserialize)]
 pub struct Pipfile {

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,11 +1,11 @@
 use crate::util::print_color;
 use crate::{commands, dep_types::Version, util};
-use crossterm::{Color, Colored};
 use flate2::read::GzDecoder;
 use regex::Regex;
 use ring::digest;
 use std::{fs, io, io::BufRead, path::Path, process::Command};
 use tar::Archive;
+use termcolor::Color;
 
 #[derive(Copy, Clone, Debug)]
 pub enum PackageType {
@@ -269,7 +269,7 @@ pub fn download_and_install_package(
                                                 f.path(),
                                                 e
                                             ),
-                                            Color::DarkYellow,
+                                            Color::Yellow, // Dark
                                         );
                                         let f_path =
                                             f.path().expect("Problem getting path from archive");
@@ -290,7 +290,7 @@ pub fn download_and_install_package(
                                         {
                                             print_color(
                                                 "Problem creating dummy readme",
-                                                Color::DarkYellow,
+                                                Color::Yellow, // Dark
                                             );
                                         }
                                     }
@@ -537,12 +537,10 @@ pub fn uninstall(name_ins: &str, vers_ins: &Version, lib_path: &Path) {
             // Some packages include a .py file directly in the lib directory instead of a folder.
             // Check that if removing the folder fails.
             if fs::remove_file(lib_path.join(&format!("{}.py", folder_name))).is_err() {
-                println!(
-                    "{}Problem uninstalling {} {}",
-                    Colored::Fg(Color::DarkRed),
-                    name_ins,
-                    vers_ins.to_string(),
-                )
+                print_color(
+                    &format!("Problem uninstalling {} {}", name_ins, vers_ins.to_string(),),
+                    Color::Red, // Dark
+                );
             }
         }
     }
@@ -556,12 +554,14 @@ pub fn uninstall(name_ins: &str, vers_ins: &Version, lib_path: &Path) {
     };
 
     if !meta_folder_removed {
-        println!(
-            "{}Problem uninstalling metadata for {}: {}",
-            Colored::Fg(Color::DarkRed),
-            name_ins,
-            vers_ins.to_string(),
-        )
+        print_color(
+            &format!(
+                "Problem uninstalling metadata for {}: {}",
+                name_ins,
+                vers_ins.to_string(),
+            ),
+            Color::Red, // Dark
+        );
     }
 
     // Remove the data directory, if it exists.

--- a/src/install.rs
+++ b/src/install.rs
@@ -173,10 +173,10 @@ pub fn download_and_install_package(
     rename: &Option<(u32, String)>,
 ) -> Result<(), reqwest::Error> {
     if !paths.lib.exists() {
-        fs::create_dir(&paths.lib).expect("Problem creating lib directory");
+        fs::create_dir_all(&paths.lib).expect("Problem creating lib directory");
     }
     if !paths.cache.exists() {
-        fs::create_dir(&paths.cache).expect("Problem creating cache directory");
+        fs::create_dir_all(&paths.cache).expect("Problem creating cache directory");
     }
     let archive_path = paths.cache.join(filename);
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -488,7 +488,11 @@ pub fn download_and_install_package(
 
 pub fn uninstall(name_ins: &str, vers_ins: &Version, lib_path: &Path) {
     #[cfg(target_os = "windows")]
-    println!("Uninstalling {}: {}...", name_ins, vers_ins.to_string());
+    println!(
+        "Uninstalling {}: {}...",
+        name_ins,
+        vers_ins.to_string_color()
+    );
     #[cfg(target_os = "linux")]
     println!("🗑 Uninstalling {}: {}...", name_ins, vers_ins.to_string());
     #[cfg(target_os = "macos")]
@@ -558,7 +562,7 @@ pub fn uninstall(name_ins: &str, vers_ins: &Version, lib_path: &Path) {
             &format!(
                 "Problem uninstalling metadata for {}: {}",
                 name_ins,
-                vers_ins.to_string(),
+                vers_ins.to_string_color(),
             ),
             Color::Red, // Dark
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use regex::Regex;
 use serde::Deserialize;
 use std::{collections::HashMap, env, error::Error, fs, path::PathBuf, str::FromStr};
 
-use atty;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
@@ -536,7 +535,7 @@ impl Config {
             result.push_str(&("py_version = \"3.8\"".to_owned() + "\n"));
         }
         if let Some(vers) = self.version {
-            result.push_str(&(format!("version = \"{}\"", vers.to_string2()) + "\n"));
+            result.push_str(&(format!("version = \"{}\"", vers.to_string() + "\n")));
         } else {
             result.push_str("version = \"0.1.0\"");
             result.push('\n');
@@ -784,7 +783,7 @@ fn sync_deps(
         util::print_color_(&format!("⬇ Installing {}", &name), Color::Cyan);
         #[cfg(target_os = "macos")]
         util::print_color_(&format!("⬇ Installing {}", &name), Color::Cyan);
-        println!("{} ...", &version);
+        println!(" {} ...", &version.to_string_color());
 
         if install::download_and_install_package(
             name,
@@ -827,7 +826,7 @@ fn sync_deps(
             install::rename_metadata(
                 &paths
                     .lib
-                    .join(&format!("{}-{}.dist-info", name, version.to_string2())),
+                    .join(&format!("{}-{}.dist-info", name, version.to_string())),
                 name,
                 new,
             );
@@ -997,7 +996,7 @@ fn run_script(
 
         fs::File::create(&py_vers_path)
             .expect("Problem creating a file to store the Python version for this script");
-        fs::write(py_vers_path, &cfg_vers.to_string2())
+        fs::write(py_vers_path, &cfg_vers.to_string())
             .expect("Problem writing Python version file.");
     }
 
@@ -1153,10 +1152,7 @@ fn sync(
             .map(|(_, name, version)| {
                 format!(
                     "{} {} pypi+https://pypi.org/pypi/{}/{}/json",
-                    name,
-                    version.to_string2(),
-                    name,
-                    version.to_string2(),
+                    name, version, name, version,
                 )
             })
             .collect();
@@ -1287,7 +1283,7 @@ fn main() {
 
     let opt = Opt::from_args();
     // Handle color option
-    let choice = match opt.color.unwrap_or(String::from("auto")).as_str() {
+    let choice = match opt.color.unwrap_or_else(|| String::from("auto")).as_str() {
         "always" => ColorChoice::Always,
         "ansi" => ColorChoice::AlwaysAnsi,
         "auto" => {

--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -3,10 +3,10 @@
 use crate::commands;
 use crate::dep_types::Version;
 use crate::{install, util};
-use crossterm::Color;
 use std::error::Error;
 #[allow(unused_imports)]
 use std::{fmt, fs, io, path::Path, path::PathBuf};
+use termcolor::Color;
 
 /// Only versions we've built and hosted
 #[derive(Clone, Copy, Debug)]

--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -408,7 +408,7 @@ pub fn create_venv(
     let installed_versions = find_installed_versions(pyflow_dir);
     for iv in &installed_versions {
         if iv.major == cfg_v.major && iv.minor == cfg_v.minor {
-            let folder_name = format!("python-{}", iv.to_string2());
+            let folder_name = format!("python-{}", iv.to_string());
             alias_path = Some(pyflow_dir.join(folder_name).join(&py_name));
             py_ver = Some(*iv);
             break;

--- a/src/util.rs
+++ b/src/util.rs
@@ -215,7 +215,7 @@ pub fn show_installed(lib_path: &Path, path_reqs: &[Req]) {
         print_color("These packages are installed:", Color::Blue); // Dark
         for (name, version, _tops) in installed {
             print_color_(&name, Color::Cyan);
-            print_color(&format!("{}", version), Color::White);
+            print_color(&format!("=={}", version.to_string_color()), Color::White);
         }
         for req in path_reqs {
             print_color_(&req.name, Color::Cyan);
@@ -739,7 +739,7 @@ pub fn find_best_release(
             abort(&format!(
                 "Unable to find a compatible release for {}: {}",
                 name,
-                version.to_string()
+                version.to_string_color()
             ));
             unreachable!()
         } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,13 +3,12 @@ use crate::{
     dep_types::{Constraint, DependencyError, Req, ReqType, Version},
     files,
     install::{self, PackageType},
-    py_versions,
+    py_versions, CliConfig,
 };
-use crossterm::{Color, Colored};
 use ini::Ini;
 use regex::Regex;
 use serde::Deserialize;
-use std::io::{self, BufRead, BufReader, Read};
+use std::io::{self, BufRead, BufReader, Read, Write};
 use std::str::FromStr;
 use std::{
     collections::HashMap,
@@ -18,6 +17,7 @@ use std::{
     process, thread, time,
 };
 use tar::Archive;
+use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
 use xz2::read::XzDecoder;
 
 #[derive(Debug)]
@@ -87,26 +87,41 @@ impl FromStr for Os {
     }
 }
 
-/// Print in a color, then reset formatting.
+/// Print line in a color, then reset formatting.
 pub fn print_color(message: &str, color: Color) {
-    println!(
-        "{}{}{}",
-        Colored::Fg(color),
-        message,
-        Colored::Fg(Color::Reset)
-    );
+    if let Err(_e) = print_color_res(message, color) {
+        panic!("Error printing in color")
+    }
+}
+
+fn print_color_res(message: &str, color: Color) -> io::Result<()> {
+    let mut stdout = StandardStream::stdout(CliConfig::current().color_choice);
+    stdout.set_color(ColorSpec::new().set_fg(Some(color)))?;
+    writeln!(&mut stdout, "{}", message)?;
+    stdout.reset()?;
+    Ok(())
+}
+
+/// Print in a color, then reset formatting. (no newline)
+pub fn print_color_(message: &str, color: Color) {
+    if let Err(_e) = print_color_res_(message, color) {
+        panic!("Error printing in color")
+    }
+}
+
+fn print_color_res_(message: &str, color: Color) -> io::Result<()> {
+    let mut stdout = StandardStream::stdout(CliConfig::current().color_choice);
+    stdout.set_color(ColorSpec::new().set_fg(Some(color)))?;
+    write!(&mut stdout, "{}", message)?;
+    stdout.reset()?;
+    Ok(())
 }
 
 /// Used when the program should exit from a condition that may arise normally from program use,
 /// like incorrect info in config files, problems with dependencies, or internet connection problems.
 /// We use `expect`, `panic!` etc for problems that indicate a bug in this program.
 pub fn abort(message: &str) {
-    println!(
-        "{}{}{}",
-        Colored::Fg(Color::Red),
-        message,
-        Colored::Fg(Color::Reset)
-    );
+    print_color(message, Color::Red);
     process::exit(1)
 }
 
@@ -195,36 +210,28 @@ pub fn show_installed(lib_path: &Path, path_reqs: &[Req]) {
     let scripts = find_console_scripts(&lib_path.join("../bin"));
 
     if installed.is_empty() {
-        print_color("No packages are installed.", Color::DarkBlue);
+        print_color("No packages are installed.", Color::Blue); // Dark
     } else {
-        print_color("These packages are installed:", Color::DarkBlue);
+        print_color("These packages are installed:", Color::Blue); // Dark
         for (name, version, _tops) in installed {
-            //        print_color(&format!("{} == \"{}\"", name, version.to_string()), Color::Magenta);
-            println!(
-                "{}{}{} == {}",
-                Colored::Fg(Color::Cyan),
-                name,
-                Colored::Fg(Color::Reset),
-                version
-            );
+            print_color_(&name, Color::Cyan);
+            print_color(&format!("{}", version), Color::White);
         }
         for req in path_reqs {
-            println!(
-                "{}{}{}, at path: {}",
-                Colored::Fg(Color::Cyan),
-                req.name,
-                Colored::Fg(Color::Reset),
-                req.path.as_ref().unwrap(),
+            print_color_(&req.name, Color::Cyan);
+            print_color(
+                &format!(", at path: {}", req.path.as_ref().unwrap()),
+                Color::White,
             );
         }
     }
 
     if scripts.is_empty() {
-        print_color("\nNo console scripts are installed.", Color::DarkBlue);
+        print_color("\nNo console scripts are installed.", Color::Blue); // Dark
     } else {
-        print_color("\nThese console scripts are installed:", Color::DarkBlue);
+        print_color("\nThese console scripts are installed:", Color::Blue); // Dark
         for script in scripts {
-            print_color(&script, Color::DarkCyan);
+            print_color(&script, Color::Cyan); // Dark
         }
     }
 }
@@ -458,9 +465,12 @@ pub fn unpack_tar_xz(archive_path: &Path, dest: &Path) {
     let mut tar: Vec<u8> = Vec::new();
     let mut decompressor = XzDecoder::new(&archive_bytes[..]);
     if decompressor.read_to_end(&mut tar).is_err() {
-        abort(&format!("Problem decompressing the archive: {:?}. This may be due to a failed downoad. \
+        abort(&format!(
+            "Problem decompressing the archive: {:?}. This may be due to a failed downoad. \
         Try deleting it, then trying again. Note that Pyflow will only install officially-released \
-        Python versions. If you'd like to use a pre-release, you must install it manually.", archive_path))
+        Python versions. If you'd like to use a pre-release, you must install it manually.",
+            archive_path
+        ))
     }
 
     // We've decompressed the .xz; now unpack the tar.


### PR DESCRIPTION
:heavy_minus_sign: crossterm
:heavy_plus_sign: termcolor
:heavy_plus_sign: atty

Termcolor allows for turning off colors by setting a ColorChoice. This
commit adds a commandline option to disable colors and also uses atty to
automatically determine if the output is being redirected and disable
colors in that case.