### PR TITLE
pyflow script now uses full path of file for env_path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -975,7 +975,7 @@ fn run_script(
     // todo: Consider a metadata file, but for now, we'll use folders
     //    let scripts_data_path = script_env_path.join("scripts.toml");
 
-    let env_path = script_env_path.join(&filename);
+    let env_path = util::canon_join(script_env_path, &filename);
     if !env_path.exists() {
         fs::create_dir_all(&env_path).expect("Problem creating environment for the script");
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -908,6 +908,27 @@ pub(crate) fn check_command_output_with(output: &process::Output, f: impl Fn(&st
     }
 }
 
+/// Take the canonicalized `path` and join `extend` onto it
+pub fn canon_join(path: &Path, extend: &str) -> PathBuf {
+    let ex_path = Path::new(extend);
+    let canon = match ex_path.canonicalize() {
+        Ok(c) => c,
+        Err(e) => {
+            abort(&format!("{}\n\"{}\"", e, extend));
+            unreachable!()
+        }
+    };
+    let mut new_path = path.to_path_buf();
+
+    for comp in canon.components() {
+        new_path = match comp {
+            std::path::Component::Normal(c) => new_path.join(c),
+            _ => new_path.join(""),
+        }
+    }
+    new_path
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;


### PR DESCRIPTION
Resolves gh-98

an absolute path broke the script_env_path location due to the way
Path.join() works. This also will allow the same script_env_path no matter
if the relative path is used or the absolute path.