### PR TITLE
Resolve Issue 77

### DIFF
--- a/src/dep_parser.rs
+++ b/src/dep_parser.rs
@@ -271,7 +271,7 @@ fn parse_modifier_version(input: &str) -> IResult<&str, VersionModifier> {
             "b" => VersionModifier::Beta,
             "rc" => VersionModifier::ReleaseCandidate,
             "dep" => VersionModifier::Dep,
-            _ => panic!("not execute this code"),
+            x => VersionModifier::Other(x.to_string()),
         },
     )(input)
 }
@@ -354,13 +354,20 @@ mod tests {
             extra_num: None,
             modifier: None,
         }))),
-        case("19.3b0", Ok(("", Version {
-            major: 19,
-            minor: 3,
-            patch: 0,
-            extra_num: None,
-            modifier: Some((VersionModifier::Beta, 0)),
-        }))),
+             case("19.3b0", Ok(("", Version {
+                 major: 19,
+                 minor: 3,
+                 patch: 0,
+                 extra_num: None,
+                 modifier: Some((VersionModifier::Beta, 0)),
+             }))),
+             case("0.4.3.dev0", Ok(("", Version {
+                 major: 0,
+                 minor: 4,
+                 patch: 3,
+                 extra_num: None,
+                 modifier: Some((VersionModifier::Other(".dev".to_string()), 0)),
+             }))),
     )]
     fn test_parse_version(input: &str, expected: IResult<&str, Version>) {
         assert_eq!(parse_version(input), expected);

--- a/src/dep_resolution.rs
+++ b/src/dep_resolution.rs
@@ -79,10 +79,11 @@ pub fn get_version_info(name: &str) -> Result<(String, Version, Vec<Version>), D
         // Unable to parse the version listed in info; iterate through releases.
         Err(_) => Ok((
             data.info.name,
-            *all_versions
+            all_versions
                 .iter()
                 .max()
-                .unwrap_or_else(|| panic!("Can't find a valid version for {}", name)),
+                .unwrap_or_else(|| panic!("Can't find a valid version for {}", name))
+                .clone(),
             all_versions,
         )),
     }
@@ -214,7 +215,7 @@ fn fetch_req_data(
             };
 
             // Ensure we don't query past the latest.
-            max_v_to_query = min(constr.compatible_range()[i].1, max_v_to_query);
+            max_v_to_query = min(constr.compatible_range()[i].1.clone(), max_v_to_query);
         }
 
         // To minimimize request time, only query the latest compatible version.
@@ -508,7 +509,7 @@ fn make_renamed_packs(
             id: dep.id,
             parent: dep.parent,
             name: dep.name.clone(),
-            version: dep.version,
+            version: dep.version.clone(),
             deps: vec![], // to be filled in after resolution
             rename,
         });
@@ -532,7 +533,7 @@ fn assign_subdeps(packages: &mut Vec<Package>, updated_ids: &HashMap<u32, u32>) 
                     None => p.parent,
                 };
                 if parent_id == package.id {
-                    Some((p.id, p.name.clone(), p.version))
+                    Some((p.id, p.name.clone(), p.version.clone()))
                 } else {
                     None
                 }
@@ -605,7 +606,7 @@ pub fn resolve(
                     id: dep.id,
                     parent: dep.parent,
                     name: fmtd_name,
-                    version: dep.version,
+                    version: dep.version.clone(),
                     deps: vec![], // to be filled in after resolution
                     rename: Rename::No,
                 });
@@ -652,7 +653,7 @@ pub fn resolve(
                         id: best.id,
                         parent: best.parent,
                         name: fmtd_name,
-                        version: best.version,
+                        version: best.version.clone(),
                         deps: vec![], // to be filled in after resolution
                         rename: Rename::No,
                     });
@@ -692,7 +693,7 @@ pub fn resolve(
                                 Some(Dependency {
                                     id: 0, // placeholder; we'll assign an id to the one we pick.
                                     name: fmtd_name.clone(),
-                                    version: *vers,
+                                    version: vers.clone(),
                                     reqs: vec![], // todo
                                     parent: 0,    // todo
                                 })

--- a/src/dep_resolution.rs
+++ b/src/dep_resolution.rs
@@ -99,7 +99,11 @@ pub fn get_warehouse_release(
     // the parsed version to the key.
     let mut version_map = HashMap::new();
     for key in data.releases.keys() {
-        version_map.insert(Version::from_str(&key).unwrap(), key.as_str());
+        if let Ok(ver) = Version::from_str(&key) {
+            version_map.insert(ver, key.as_str());
+        } else if cfg!(debug_assertions) {
+            eprintln!("Unable to parse \"{}\" version \"{}\"; skipped.", name, key);
+        }
     }
 
     let key = version_map

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,7 @@ impl Config {
                     }
                     if &name.to_lowercase() == "python" {
                         if let Some(constr) = constraints.get(0) {
-                            result.py_version = Some(constr.version)
+                            result.py_version = Some(constr.version.clone())
                         }
                     } else {
                         result.reqs.push(Req {
@@ -534,7 +534,7 @@ impl Config {
         } else {
             result.push_str(&("py_version = \"3.8\"".to_owned() + "\n"));
         }
-        if let Some(vers) = self.version {
+        if let Some(vers) = self.version.clone() {
             result.push_str(&(format!("version = \"{}\"", vers.to_string() + "\n")));
         } else {
             result.push_str("version = \"0.1.0\"");
@@ -714,7 +714,7 @@ fn sync_deps(
     let installed: Vec<(String, Version)> = installed
         .iter()
         // Don't standardize name here; see note below in to_uninstall.
-        .map(|t| (t.0.clone(), t.1))
+        .map(|t| (t.0.clone(), t.1.clone()))
         .collect();
 
     // Filter by not-already-installed.
@@ -742,7 +742,7 @@ fn sync_deps(
         .filter(|inst| {
             // Don't standardize the name here; we need original capitalization to uninstall
             // metadata etc.
-            let inst = (inst.0.clone(), inst.1);
+            let inst = (inst.0.clone(), inst.1.clone());
             let mut contains = false;
             // We can't just use the contains method, due to needing compare_names().
             for pack in &packages_only {
@@ -1134,7 +1134,7 @@ fn sync(
     let mut updated_lock_packs = vec![];
 
     for package in &resolved {
-        let dummy_constraints = vec![Constraint::new(ReqType::Exact, package.version)];
+        let dummy_constraints = vec![Constraint::new(ReqType::Exact, package.version.clone())];
         if already_locked(&locked, &package.name, &dummy_constraints) {
             let existing: Vec<&LockPackage> = lockpacks
                 .iter()
@@ -1423,8 +1423,8 @@ fn main() {
         }
         SubCommand::Switch { version } => {
             // Updates `pyproject.toml` with a new python version
-            let specified = util::fallible_v_parse(&version);
-            cfg.py_version = Some(specified);
+            let specified = util::fallible_v_parse(&version.clone());
+            cfg.py_version = Some(specified.clone());
             files::change_py_vers(&PathBuf::from(&cfg_path), &specified);
             util::print_color(
                 &format!(
@@ -1454,7 +1454,7 @@ fn main() {
         _ => (),
     }
 
-    let cfg_vers = if let Some(v) = cfg.py_version {
+    let cfg_vers = if let Some(v) = cfg.py_version.clone() {
         v
     } else {
         let specified = util::prompt_py_vers();

--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -457,7 +457,7 @@ pub fn create_venv(
         // and we're using its `python`.
         #[cfg(target_os = "linux")]
         {
-            match py_ver.unwrap().minor {
+            match py_ver.clone().unwrap().minor {
                 12 => py_name += ".12",
                 11 => py_name += ".11",
                 10 => py_name += ".10",

--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -234,7 +234,7 @@ fn download(py_install_path: &Path, version: &Version) {
     }
 
     // Match up our version to the closest match (major+minor will match) we've built.
-    let vers_to_dl2: PyVers = (*version, os).into();
+    let vers_to_dl2: PyVers = (version.clone(), os).into();
     let vers_to_dl = vers_to_dl2.to_string();
 
     let url = format!(
@@ -410,7 +410,7 @@ pub fn create_venv(
         if iv.major == cfg_v.major && iv.minor == cfg_v.minor {
             let folder_name = format!("python-{}", iv.to_string());
             alias_path = Some(pyflow_dir.join(folder_name).join(&py_name));
-            py_ver = Some(*iv);
+            py_ver = Some(iv.clone());
             break;
         }
     }
@@ -447,7 +447,7 @@ pub fn create_venv(
         // Download and install the appropriate Python binary, if we can't find either a
         // custom install, or on the Path.
         download(pyflow_dir, cfg_v);
-        let py_ver2: PyVers = (*cfg_v, os).into();
+        let py_ver2: PyVers = (cfg_v.clone(), os).into();
         py_ver = Some(py_ver2.to_vers());
 
         let folder_name = format!("python-{}", py_ver2.to_string());


### PR DESCRIPTION
The way I went about fixing this introduced some major changes.

The initial issue was that we were trying to pick the correct release version by using our parsed version. That ran into a problem when the version number was `0.07` and parsed down to `0.7.0` and that couldn't find a release version to match. I then thought, why not build a reverse map so we can grab the actual json key based on the parsed `Version`

That worked fine, but I ran into an issue when I was randomly testing package installs and came across a `boltons` package release with the version `0.3.4.dev0`. I looked into the `VersionModifier` code and having seen enums with a type containing a string I thought I would implement that `VersionModifier::Other(String)`. That required me to remove the `Copy` trait and clone the values explicitly where needed.

I added a test for the new strange `0.3.4.dev0` case and modified `parse_modifier_version` so that all tests passed.

I think this is a more robust way to handle the `VersionModifier` and should prevent any other strange versioning from causing problems.

