### PR TITLE
Star requirements

### DIFF
--- a/src/dep_parser.rs
+++ b/src/dep_parser.rs
@@ -473,11 +473,10 @@ mod tests {
                      Constraint::new(ReqType::Exact, Version::new_star(Some(0), Some(3), None, true))
                  ]
              )))),
-             #[should_panic]
-             case::star_patch_should_fail("saturn = \"0.3.*\"", Ok(("", Req::new(
+             case::star_extra_num("saturn = \"0.3.4.*\"", Ok(("", Req::new(
                  "saturn".to_string(),
                  vec![
-                     Constraint::new(ReqType::Exact, Version::new_star(Some(0), Some(3), None, false))
+                     Constraint::new(ReqType::Exact, Version::new_star(Some(0), Some(3), Some(4), true))
                  ]
              ))))
     )]

--- a/src/dep_parser.rs
+++ b/src/dep_parser.rs
@@ -212,10 +212,33 @@ pub fn parse_version(input: &str) -> IResult<&str, Version> {
         opt(preceded(tag("."), parse_digit_or_wildcard)),
     ))(input)?;
     let (remain, modifire) = parse_modifier(remain)?;
-
-    let mut version = Version::new(major, minor.unwrap_or(0), patch.unwrap_or(0));
+    // TODO: check if u32::MAX in any version. (marker for `*`). then set that field
+    // and any subsequent fields to `None`
+    let mut version = Version::new_opt(Some(major), minor, patch);
     version.extra_num = extra_num;
     version.modifier = modifire;
+    version.star = vec![Some(major), minor, patch, extra_num].contains(&Some(u32::MAX));
+    if version.star {
+        if version.major == Some(u32::MAX) {
+            version.major = None;
+            version.minor = None;
+            version.patch = None;
+            version.extra_num = None;
+            version.modifier = None;
+        } else if version.minor == Some(u32::MAX) {
+            version.minor = None;
+            version.patch = None;
+            version.extra_num = None;
+            version.modifier = None;
+        } else if version.patch == Some(u32::MAX) {
+            version.patch = None;
+            version.extra_num = None;
+            version.modifier = None;
+        } else if version.extra_num == Some(u32::MAX) {
+            version.extra_num = None;
+            version.modifier = None;
+        }
+    }
 
     Ok((remain, version))
 }
@@ -251,9 +274,10 @@ fn is_package_char(c: char) -> bool {
 }
 
 fn parse_digit_or_wildcard(input: &str) -> IResult<&str, u32> {
-    map(alt((digit1, value("0", tag("*")))), |digit: &str| {
-        digit.parse().unwrap()
-    })(input)
+    map(
+        alt((digit1, value("4294967295", tag("*")))),
+        |digit: &str| digit.parse().unwrap(),
+    )(input)
 }
 
 fn parse_modifier(input: &str) -> IResult<&str, Option<(VersionModifier, u32)>> {
@@ -296,75 +320,85 @@ mod tests {
 
     #[rstest(input, expected,
         case("3.12.5", Ok(("", Version {
-            major: 3,
+            major: Some(3),
             minor: Some(12),
             patch: Some(5),
             extra_num: None,
             modifier: None,
+            star: false,
         }))),
         case("0.1.0", Ok(("", Version {
-            major: 0,
+            major: Some(0),
             minor: Some(1),
             patch: Some(0),
             extra_num: None,
             modifier: None,
+            star: false,
         }))),
         case("3.7", Ok(("", Version {
-            major: 3,
+            major: Some(3),
             minor: Some(7),
             patch: Some(0),
             extra_num: None,
             modifier: None,
+            star: false,
         }))),
         case("1", Ok(("", Version {
-            major: 1,
+            major: Some(1),
             minor: Some(0),
             patch: Some(0),
             extra_num: None,
             modifier: None,
+            star: false,
         }))),
         case("3.2.*", Ok(("", Version {
-            major: 3,
+            major: Some(3),
             minor: Some(2),
-            patch: Some(0),
+            patch: None,
             extra_num: None,
             modifier: None,
+            star: true,
         }))),
         case("1.*", Ok(("", Version {
-            major: 1,
-            minor: Some(0),
-            patch: Some(0),
+            major: Some(1),
+            minor: None,
+            patch: None,
             extra_num: None,
             modifier: None,
+            star: true,
         }))),
         case("1.*.*", Ok(("", Version {
-            major: 1,
-            minor: Some(0),
-            patch: Some(0),
+            major: Some(1),
+            minor: None,
+            patch: None,
             extra_num: None,
             modifier: None,
+            star: true,
         }))),
         case("19.3", Ok(("", Version {
-            major: 19,
+            major: Some(19),
             minor: Some(3),
             patch: Some(0),
             extra_num: None,
             modifier: None,
+            star: false,
         }))),
         case("19.3b0", Ok(("", Version {
-                 major: 19,
+                 major: Some(19),
                  minor: Some(3),
                  patch: Some(0),
                  extra_num: None,
                  modifier: Some((VersionModifier::Beta, 0)),
+                 star: false,
         }))),
         // This package version showed up in boltons history
         case("0.4.3.dev0", Ok(("", Version {
-                 major: 0,
+                 major: Some(0),
                  minor: Some(4),
                  patch: Some(3),
                  extra_num: None,
                  modifier: Some((VersionModifier::Other("dev".to_string()), 0)),
+                 star: false,
         }))),
     )]
     fn test_parse_version(input: &str, expected: IResult<&str, Version>) {

--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -37,7 +37,7 @@ impl From<(Version, Os)> for PyVers {
     fn from(v_o: (Version, Os)) -> Self {
         let unsupported = "Unsupported python version requested; only Python ≥ 3.4 is supported. \
         to fix this, edit the `py_version` line of `pyproject.toml`, or run `pyflow switch 3.7`";
-        if v_o.0.major != 3 {
+        if v_o.0.major != Some(3) {
             util::abort(unsupported);
             unreachable!()
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -489,7 +489,7 @@ pub fn find_or_create_venv(
     // The version's explicitly specified; check if an environment for that version
     let compatible_venvs: Vec<&(u32, u32)> = venvs
         .iter()
-        .filter(|(ma, mi)| cfg_vers.major == *ma && cfg_vers.minor == Some(*mi))
+        .filter(|(ma, mi)| cfg_vers.major == Some(*ma) && cfg_vers.minor == Some(*mi))
         .collect();
 
     let vers_path;


### PR DESCRIPTION
This pull request adds the ability to handle `*` requirements in any position. The basics of compatibility work, but I don't know if we are full there with meeting PEP 440. Specifically [Version Matching](https://www.python.org/dev/peps/pep-0440/#version-matching)

Specifically the following case:
```
== 1.1        # Not equal, so 1.1a1 does not match clause
== 1.1a1      # Equal, so 1.1a1 matches clause
== 1.1.*      # Same prefix, so 1.1a1 matches clause
```

This does resolve gh-117 (at least it did for my trial)

```
Found lockfile
Installing toml 0.10.2 ...
Installing typed_ast 1.4.3 ...
Installing appdirs 1.4.4 ...
Installing asgiref 3.3.4 ...
Installing regex 2021.4.4 ...
Installing pathspec 0.8.1 ...
Installing click 8.0.1 ...
Installing uvicorn 0.14.0 ...
Added a console script: uvicorn
Installing h11 0.12.0 ...
Installing mypy_extensions 0.4.3 ...
Installing black 21.6b0 ...
Added a console script: black
Added a console script: black-primer
Added a console script: blackd
Installation complete
```