### PR TITLE
Remedy warnings generated by clippy

### DIFF
--- a/src/dep_resolution.rs
+++ b/src/dep_resolution.rs
@@ -78,7 +78,7 @@ struct MultipleBody {
 // guess_graph removed from mod res because of lifetime issue with automock
 // Build a graph: Start by assuming we can pick the newest compatible dependency at each step.
 // If unable to resolve this way, subsequently run this with additional deconfliction reqs.
-#[allow(clippy::clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn guess_graph(
     parent_id: u32,
     reqs: &[Req],

--- a/src/install.rs
+++ b/src/install.rs
@@ -160,7 +160,7 @@ pub fn setup_scripts(name: &str, version: &Version, lib_path: &Path, entry_pt_pa
 
 /// Download and install a package. For wheels, we can just extract the contents into
 /// the lib folder.  For source dists, make a wheel first.
-#[allow(clippy::clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub fn download_and_install_package(
     name: &str,
     version: &Version,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1114,7 +1114,7 @@ fn run_script(
 
 /// Function used by `Install` and `Uninstall` subcommands to syn dependencies with
 /// the config and lock files.
-#[allow(clippy::clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn sync(
     paths: &util::Paths,
     lockpacks: &[LockPackage],


### PR DESCRIPTION
The contributing guide asks to run `cargo clippy` before submitting PRs. When doing so, I got eight warnings similar to 

```
warning: unknown lint: `clippy::clippy::too_many_arguments`
   --> src/install.rs:163:9
    |
163 | #[allow(clippy::clippy::too_many_arguments)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: did you mean: `clippy::too_many_arguments`
```

`clippy` version: clippy 0.1.53 (53cb7b09 2021-06-17)