### PR TITLE
Resolve some DRY comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 #PyCharm
 *.iws
 *.workspace.xml
+.idea
 
 # Prevent generated and test files from being committed
 requirements.txt


### PR DESCRIPTION
This MR addresses two areas of DRY.

1. `SubCommand::Install` had duplicate code for installing dependencies and dev-dependencies.
2. `files.rs` had duplicate code for adding dependencies/dev-dependencies to `pyproject.toml`.

I should note that some of the tests in `files.rs` have been modified. Previously, it was expecting two newlines (one full blank line plus an additional newline) at the end of the file. I would argue that there should be only one newline.