### PR TITLE
Allow Python version to be set with `__python__` variable in script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ dependencies = [
  "itoa",
  "log",
  "net2",
- "rustc_version",
+ "rustc_version 0.2.3",
  "time",
  "tokio",
  "tokio-buf",
@@ -906,7 +906,7 @@ checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
  "lock_api",
  "parking_lot_core",
- "rustc_version",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -919,7 +919,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall 0.1.57",
- "rustc_version",
+ "rustc_version 0.2.3",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -935,6 +935,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1260,14 +1269,14 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.6.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+checksum = "041bb0202c14f6a158bbbf086afb03d0c6e975c2dec7d4912f8061ed44f290af"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.3.3",
  "syn",
 ]
 
@@ -1289,7 +1298,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -1333,7 +1351,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -1341,6 +1368,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1730,6 +1766,12 @@ checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ reqwest = { version = "^0.9.21", default-features = false, features = ["rustls-t
 mockall_double = "^0.2.0"
 
 [dev-dependencies]
-rstest = "0.6.4"
+rstest = "0.10.0"
 mockall = "^0.9"
 
 [package.metadata.deb]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ creates a folder with the basics.
 ## Quick-and-dirty start for quick-and-dirty scripts
 - Add the line `__requires__ = ['numpy', 'requests']` somewhere in your script, where `numpy` and
 `requests` are dependencies.
-Run `pyflow script myscript.py`, where `myscript.py` is the name of your script.
+- Optionally add the line `__python__ = X.Y.Z`, where `X.Y.Z` is a Python version specification.
+Without this line, you will be prompted to choose a version when running the script.
+- Run `pyflow script myscript.py`, where `myscript.py` is the name of your script.
 This will set up an isolated environment for this script, and install
 dependencies as required. This is a safe way
 to run one-off Python files that aren't attached to a project, but have dependencies.

--- a/src/files.rs
+++ b/src/files.rs
@@ -187,7 +187,6 @@ fn extend_or_insert(mut cfg_lines: Vec<String>, section_header: &str, reqs: &[Re
     match collected {
         // The section already exists, so we can just add the new reqs
         Some(section) => {
-
             // To enforce proper spacing we first remove any empty lines,
             // and later we append a trailing empty line
             let mut all_deps: Vec<String> = section

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,13 @@
 
 #[mockall_double::double]
 use crate::dep_resolution::res;
-use crate::dep_types::{
-    Constraint, Extras, Lock, LockPackage, Package, Rename, Req, ReqType, Version,
-};
+use crate::dep_types::{Constraint, Lock, LockPackage, Package, Rename, Req, ReqType, Version};
 use crate::util::{abort, process_reqs, Os};
 
 use regex::Regex;
 use serde::Deserialize;
 use std::{collections::HashMap, env, error::Error, fs, path::PathBuf, str::FromStr};
 
-use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use structopt::StructOpt;
@@ -25,6 +22,7 @@ mod dep_types;
 mod files;
 mod install;
 mod py_versions;
+mod script;
 mod util;
 
 // todo:
@@ -712,19 +710,6 @@ __pypackages__/
     Ok(())
 }
 
-/// Read dependency data from a lock file.
-fn read_lock(path: &Path) -> Result<Lock, Box<dyn Error>> {
-    let data = fs::read_to_string(path)?;
-    Ok(toml::from_str(&data)?)
-}
-
-/// Write dependency data to a lock file.
-fn write_lock(path: &Path, data: &Lock) -> Result<(), Box<dyn Error>> {
-    let data = toml::to_string(data)?;
-    fs::write(path, data)?;
-    Ok(())
-}
-
 fn parse_lockpack_rename(rename: &str) -> (u32, String) {
     let re = Regex::new(r"^(\d+)\s(.*)$").unwrap();
     let caps = re
@@ -972,153 +957,6 @@ fn run_cli_tool(
     }
 }
 
-/// Find a script's dependencies from a variable: `__requires__ = [dep1, dep2]`
-fn find_deps_from_script(file_path: &Path) -> Vec<String> {
-    // todo: Helper for this type of logic? We use it several times in the program.
-    let f = fs::File::open(file_path).expect("Problem opening the Python script file.");
-
-    let re = Regex::new(r"^__requires__\s*=\s*\[(.*?)\]$").unwrap();
-
-    let mut result = vec![];
-    for line in BufReader::new(f).lines().flatten() {
-        if let Some(c) = re.captures(&line) {
-            let deps_list = c.get(1).unwrap().as_str().to_owned();
-            let deps: Vec<&str> = deps_list.split(',').collect();
-            result = deps
-                .into_iter()
-                .map(|d| {
-                    d.to_owned()
-                        .replace(" ", "")
-                        .replace("\"", "")
-                        .replace("'", "")
-                })
-                .filter(|d| !d.is_empty())
-                .collect();
-        }
-    }
-
-    result
-}
-
-/// Run a standalone script file, with package management
-/// // todo: Perhaps move this logic to its own file, if it becomes long.
-/// todo: We're using script name as unique identifier; address this in the future,
-/// todo perhaps with an id in a comment at the top of a file
-fn run_script(
-    script_env_path: &Path,
-    dep_cache_path: &Path,
-    os: util::Os,
-    args: &[String],
-    pyflow_dir: &Path,
-) {
-    #[cfg(debug_assertions)]
-    eprintln!("Run script args: {:?}", args);
-    // todo: DRY with run_cli_tool and subcommand::Install
-    let filename = if let Some(a) = args.get(0) {
-        a.clone()
-    } else {
-        abort("`script` must be followed by the script to run, eg `pyflow script myscript.py`");
-        unreachable!()
-    };
-
-    // todo: Consider a metadata file, but for now, we'll use folders
-    //    let scripts_data_path = script_env_path.join("scripts.toml");
-
-    let env_path = util::canon_join(script_env_path, &filename);
-    if !env_path.exists() {
-        fs::create_dir_all(&env_path).expect("Problem creating environment for the script");
-    }
-
-    // Write the version we found to a file.
-    let cfg_vers;
-    let py_vers_path = env_path.join("py_vers.txt");
-
-    if py_vers_path.exists() {
-        cfg_vers = Version::from_str(
-            &fs::read_to_string(py_vers_path)
-                .expect("Problem reading Python version for this script")
-                .replace("\n", ""),
-        )
-        .expect("Problem parsing version from file");
-    } else {
-        cfg_vers = util::prompt_py_vers();
-
-        fs::File::create(&py_vers_path)
-            .expect("Problem creating a file to store the Python version for this script");
-        fs::write(py_vers_path, &cfg_vers.to_string())
-            .expect("Problem writing Python version file.");
-    }
-
-    // todo DRY
-    let pypackages_dir = env_path.join("__pypackages__");
-    let (vers_path, py_vers) =
-        util::find_or_create_venv(&cfg_vers, &pypackages_dir, pyflow_dir, dep_cache_path);
-
-    let bin_path = util::find_bin_path(&vers_path);
-    let lib_path = vers_path.join("lib");
-    let script_path = vers_path.join("bin");
-    let lock_path = env_path.join("pyproject.lock");
-
-    let paths = util::Paths {
-        bin: bin_path,
-        lib: lib_path,
-        entry_pt: script_path,
-        cache: dep_cache_path.to_owned(),
-    };
-
-    let deps = find_deps_from_script(&PathBuf::from(&filename));
-
-    let lock = match read_lock(&lock_path) {
-        Ok(l) => l,
-        Err(_) => Lock::default(),
-    };
-
-    let lockpacks = lock.package.unwrap_or_else(Vec::new);
-
-    let reqs: Vec<Req> = deps
-        .iter()
-        .map(|name| {
-            let (fmtd_name, version) = if let Some(lp) = lockpacks
-                .iter()
-                .find(|lp| util::compare_names(&lp.name, name))
-            {
-                (
-                    lp.name.clone(),
-                    Version::from_str(&lp.version).expect("Problem getting version"),
-                )
-            } else {
-                let vinfo = res::get_version_info(
-                    name,
-                    Some(Req::new_with_extras(
-                        name.to_string(),
-                        vec![Constraint::new_any()],
-                        Extras::new_py(Constraint::new(ReqType::Exact, py_vers.clone())),
-                    )),
-                )
-                .unwrap_or_else(|_| panic!("Problem getting version info for {}", &name));
-                (vinfo.0, vinfo.1)
-            };
-
-            Req::new(fmtd_name, vec![Constraint::new(ReqType::Caret, version)])
-        })
-        .collect();
-
-    sync(
-        &paths,
-        &lockpacks,
-        &reqs,
-        &[],
-        &[],
-        os,
-        &py_vers,
-        &lock_path,
-    );
-
-    if commands::run_python(&paths.bin, &[paths.lib], args).is_err() {
-        abort("Problem running this script")
-    };
-}
-
 /// Function used by `Install` and `Uninstall` subcommands to syn dependencies with
 /// the config and lock files.
 #[allow(clippy::too_many_arguments)]
@@ -1236,7 +1074,7 @@ fn sync(
         metadata: HashMap::new(), // todo: Problem with toml conversion.
         package: Some(updated_lock_packs.clone()),
     };
-    if write_lock(lock_path, &updated_lock).is_err() {
+    if util::write_lock(lock_path, &updated_lock).is_err() {
         abort("Problem writing lock file");
     }
 
@@ -1373,7 +1211,7 @@ fn main() {
     // Run this before parsing the config.
     if let Some(x) = extcmd.clone() {
         if let ExternalSubcommands::Script = x.cmd {
-            run_script(&script_env_path, &dep_cache_path, os, &x.args, &pyflow_path);
+            script::run_script(&script_env_path, &dep_cache_path, os, &x.args, &pyflow_path);
             return;
         }
     }
@@ -1531,7 +1369,7 @@ fn main() {
     }
 
     let mut found_lock = false;
-    let lock = match read_lock(&lock_path) {
+    let lock = match util::read_lock(&lock_path) {
         Ok(l) => {
             found_lock = true;
             l

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,0 +1,157 @@
+use crate::dep_resolution::res;
+use crate::dep_types::{Constraint, Extras, Lock, Req, ReqType, Version};
+use crate::util;
+use regex::Regex;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+use crate::commands;
+use std::str::FromStr;
+
+/// Run a standalone script file, with package management
+/// todo: We're using script name as unique identifier; address this in the future,
+/// todo perhaps with an id in a comment at the top of a file
+pub fn run_script(
+    script_env_path: &Path,
+    dep_cache_path: &Path,
+    os: util::Os,
+    args: &[String],
+    pyflow_dir: &Path,
+) {
+    #[cfg(debug_assertions)]
+    eprintln!("Run script args: {:?}", args);
+    // todo: DRY with run_cli_tool and subcommand::Install
+    let filename = if let Some(a) = args.get(0) {
+        a.clone()
+    } else {
+        util::abort(
+            "`script` must be followed by the script to run, eg `pyflow script myscript.py`",
+        );
+        unreachable!()
+    };
+
+    // todo: Consider a metadata file, but for now, we'll use folders
+    //    let scripts_data_path = script_env_path.join("scripts.toml");
+
+    let env_path = util::canon_join(script_env_path, &filename);
+    if !env_path.exists() {
+        fs::create_dir_all(&env_path).expect("Problem creating environment for the script");
+    }
+
+    // Write the version we found to a file.
+    let cfg_vers;
+    let py_vers_path = env_path.join("py_vers.txt");
+
+    if py_vers_path.exists() {
+        cfg_vers = Version::from_str(
+            &fs::read_to_string(py_vers_path)
+                .expect("Problem reading Python version for this script")
+                .replace("\n", ""),
+        )
+        .expect("Problem parsing version from file");
+    } else {
+        cfg_vers = util::prompt_py_vers();
+
+        fs::File::create(&py_vers_path)
+            .expect("Problem creating a file to store the Python version for this script");
+        fs::write(py_vers_path, &cfg_vers.to_string())
+            .expect("Problem writing Python version file.");
+    }
+
+    // todo DRY
+    let pypackages_dir = env_path.join("__pypackages__");
+    let (vers_path, py_vers) =
+        util::find_or_create_venv(&cfg_vers, &pypackages_dir, pyflow_dir, dep_cache_path);
+
+    let bin_path = util::find_bin_path(&vers_path);
+    let lib_path = vers_path.join("lib");
+    let script_path = vers_path.join("bin");
+    let lock_path = env_path.join("pyproject.lock");
+
+    let paths = util::Paths {
+        bin: bin_path,
+        lib: lib_path,
+        entry_pt: script_path,
+        cache: dep_cache_path.to_owned(),
+    };
+
+    let deps = find_deps_from_script(&PathBuf::from(&filename));
+
+    let lock = match util::read_lock(&lock_path) {
+        Ok(l) => l,
+        Err(_) => Lock::default(),
+    };
+
+    let lockpacks = lock.package.unwrap_or_else(Vec::new);
+
+    let reqs: Vec<Req> = deps
+        .iter()
+        .map(|name| {
+            let (fmtd_name, version) = if let Some(lp) = lockpacks
+                .iter()
+                .find(|lp| util::compare_names(&lp.name, name))
+            {
+                (
+                    lp.name.clone(),
+                    Version::from_str(&lp.version).expect("Problem getting version"),
+                )
+            } else {
+                let vinfo = res::get_version_info(
+                    name,
+                    Some(Req::new_with_extras(
+                        name.to_string(),
+                        vec![Constraint::new_any()],
+                        Extras::new_py(Constraint::new(ReqType::Exact, py_vers.clone())),
+                    )),
+                )
+                .unwrap_or_else(|_| panic!("Problem getting version info for {}", &name));
+                (vinfo.0, vinfo.1)
+            };
+
+            Req::new(fmtd_name, vec![Constraint::new(ReqType::Caret, version)])
+        })
+        .collect();
+
+    crate::sync(
+        &paths,
+        &lockpacks,
+        &reqs,
+        &[],
+        &[],
+        os,
+        &py_vers,
+        &lock_path,
+    );
+
+    if commands::run_python(&paths.bin, &[paths.lib], args).is_err() {
+        util::abort("Problem running this script")
+    };
+}
+
+/// Find a script's dependencies from a variable: `__requires__ = [dep1, dep2]`
+fn find_deps_from_script(file_path: &Path) -> Vec<String> {
+    // todo: Helper for this type of logic? We use it several times in the program.
+    let f = fs::File::open(file_path).expect("Problem opening the Python script file.");
+
+    let re = Regex::new(r"^__requires__\s*=\s*\[(.*?)\]$").unwrap();
+
+    let mut result = vec![];
+    for line in BufReader::new(f).lines().flatten() {
+        if let Some(c) = re.captures(&line) {
+            let deps_list = c.get(1).unwrap().as_str().to_owned();
+            let deps: Vec<&str> = deps_list.split(',').collect();
+            result = deps
+                .into_iter()
+                .map(|d| {
+                    d.to_owned()
+                        .replace(" ", "")
+                        .replace("\"", "")
+                        .replace("'", "")
+                })
+                .filter(|d| !d.is_empty())
+                .collect();
+        }
+    }
+    result
+}

--- a/src/script.rs
+++ b/src/script.rs
@@ -3,10 +3,10 @@ use crate::dep_types::{Constraint, Extras, Lock, Req, ReqType, Version};
 use crate::util;
 use regex::Regex;
 use std::fs;
-use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::commands;
+use crate::dep_parser::parse_version;
 use std::str::FromStr;
 
 /// Run a standalone script file, with package management
@@ -21,9 +21,10 @@ pub fn run_script(
 ) {
     #[cfg(debug_assertions)]
     eprintln!("Run script args: {:?}", args);
+
     // todo: DRY with run_cli_tool and subcommand::Install
-    let filename = if let Some(a) = args.get(0) {
-        a.clone()
+    let filename = if let Some(arg) = args.get(0) {
+        arg
     } else {
         util::abort(
             "`script` must be followed by the script to run, eg `pyflow script myscript.py`",
@@ -43,7 +44,13 @@ pub fn run_script(
     let cfg_vers;
     let py_vers_path = env_path.join("py_vers.txt");
 
-    if py_vers_path.exists() {
+    let script = fs::read_to_string(filename).expect("Problem opening the Python script file.");
+    let dunder_python_vers = check_for_specified_py_vers(&script);
+
+    if let Some(dpv) = dunder_python_vers {
+        cfg_vers = dpv;
+        create_or_update_version_file(&py_vers_path, &cfg_vers);
+    } else if py_vers_path.exists() {
         cfg_vers = Version::from_str(
             &fs::read_to_string(py_vers_path)
                 .expect("Problem reading Python version for this script")
@@ -52,11 +59,7 @@ pub fn run_script(
         .expect("Problem parsing version from file");
     } else {
         cfg_vers = util::prompt_py_vers();
-
-        fs::File::create(&py_vers_path)
-            .expect("Problem creating a file to store the Python version for this script");
-        fs::write(py_vers_path, &cfg_vers.to_string())
-            .expect("Problem writing Python version file.");
+        create_or_update_version_file(&py_vers_path, &cfg_vers);
     }
 
     // todo DRY
@@ -76,7 +79,7 @@ pub fn run_script(
         cache: dep_cache_path.to_owned(),
     };
 
-    let deps = find_deps_from_script(&PathBuf::from(&filename));
+    let deps = find_deps_from_script(&script);
 
     let lock = match util::read_lock(&lock_path) {
         Ok(l) => l,
@@ -129,15 +132,55 @@ pub fn run_script(
     };
 }
 
-/// Find a script's dependencies from a variable: `__requires__ = [dep1, dep2]`
-fn find_deps_from_script(file_path: &Path) -> Vec<String> {
-    // todo: Helper for this type of logic? We use it several times in the program.
-    let f = fs::File::open(file_path).expect("Problem opening the Python script file.");
+/// Create the `py_vers.txt` if it doesn't exist, and then store `cfg_vers` within.
+fn create_or_update_version_file(py_vers_path: &Path, cfg_vers: &Version) {
+    if !py_vers_path.exists() {
+        fs::File::create(&py_vers_path)
+            .expect("Problem creating a file to store the Python version for this script");
+    }
+    fs::write(py_vers_path, &cfg_vers.to_string()).expect("Problem writing Python version file.");
+}
 
+/// Find a script's Python version specificion by looking for the `__python__` variable.
+///
+/// If a `__python__` variable is identified, the version must have major, minor, and
+/// patch components to be considered valid. Otherwise, there is still some ambiguity in
+/// which version to use and an error is thrown.
+fn check_for_specified_py_vers(script: &str) -> Option<Version> {
+    let re = Regex::new(r#"^__python__\s*=\s*"(.*?)"$"#).unwrap();
+
+    for line in script.lines() {
+        if let Some(capture) = re.captures(&line) {
+            let specification = capture.get(1).unwrap().as_str();
+            let (_, version) = parse_version(specification).unwrap();
+            match version {
+                Version {
+                    major: Some(_),
+                    minor: Some(_),
+                    patch: Some(_),
+                    extra_num: None,
+                    modifier: None,
+                    ..
+                } => return Some(version),
+                _ => {
+                    util::abort(
+                        "Problem parsing `__python__` variable. Make sure you've included \
+                        major, minor, and patch specifications (eg `__python__ = X.Y.Z`)",
+                    );
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Find a script's dependencies from a variable: `__requires__ = [dep1, dep2]`
+fn find_deps_from_script(script: &str) -> Vec<String> {
+    // todo: Helper for this type of logic? We use it several times in the program.
     let re = Regex::new(r"^__requires__\s*=\s*\[(.*?)\]$").unwrap();
 
     let mut result = vec![];
-    for line in BufReader::new(f).lines().flatten() {
+    for line in script.lines() {
         if let Some(c) = re.captures(&line) {
             let deps_list = c.get(1).unwrap().as_str().to_owned();
             let deps: Vec<&str> = deps_list.split(',').collect();
@@ -154,4 +197,43 @@ fn find_deps_from_script(file_path: &Path) -> Vec<String> {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dep_types::Version;
+    use crate::script::check_for_specified_py_vers;
+    use rstest::rstest;
+
+    const NO_DUNDER_PYTHON: &str = r#"
+if __name__ == "__main__":
+    print("Hello, world")
+"#;
+
+    const VALID_DUNDER_PYTHON: &str = r#"
+__python__ = "3.9.1"
+
+if __name__ == "__main__":
+    print("Hello, world")
+"#;
+
+    fn py_version() -> Option<Version> {
+        let version = Version {
+            major: Some(3),
+            minor: Some(9),
+            patch: Some(1),
+            extra_num: None,
+            modifier: None,
+            star: false,
+        };
+        Some(version)
+    }
+
+    #[rstest]
+    #[case(NO_DUNDER_PYTHON, None)]
+    #[case(VALID_DUNDER_PYTHON, py_version())]
+    fn dunder_python_specified(#[case] src: &str, #[case] expected: Option<Version>) {
+        let result = check_for_specified_py_vers(src);
+        assert_eq!(result, expected)
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use crate::dep_resolution::WarehouseRelease;
 use crate::dep_types::Extras;
 use crate::{
     commands,
-    dep_types::{Constraint, DependencyError, Req, ReqType, Version},
+    dep_types::{Constraint, DependencyError, Lock, Req, ReqType, Version},
     files,
     install::{self, PackageType},
     py_versions, util, CliConfig,
@@ -17,7 +17,9 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::str::FromStr;
 use std::{
     collections::HashMap,
-    env, fs,
+    env,
+    error::Error,
+    fs,
     path::{Path, PathBuf},
     process, thread, time,
 };
@@ -984,6 +986,19 @@ pub fn process_reqs(reqs: Vec<Req>, git_path: &Path, paths: &util::Paths) -> Vec
         updated_reqs.push(r);
     }
     updated_reqs
+}
+
+/// Read dependency data from a lock file.
+pub fn read_lock(path: &Path) -> Result<Lock, Box<dyn Error>> {
+    let data = fs::read_to_string(path)?;
+    Ok(toml::from_str(&data)?)
+}
+
+/// Write dependency data to a lock file.
+pub fn write_lock(path: &Path, data: &Lock) -> Result<(), Box<dyn Error>> {
+    let data = toml::to_string(data)?;
+    fs::write(path, data)?;
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implementation of #130 

Setting a `__python__` variable in your script overrides and overwrites any previously stored version information in `py_vers.txt`. A full Python version specification (X.Y.Z) is required, and the program is aborted if only a partial specification is detected.

This MR also bumps `rstest` to the latest version `0.10.0`, which allows for improved test-writing syntax.