### PR TITLE
Give a root folder to source distribution zips without a root folder

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -36,8 +36,8 @@ fn replace_distutils(setup_path: &Path) {
         t
     } else {
         util::abort(&format!(
-            "Can't find setup.py in this source distribution\
-             path: {:?}. This could mean there are no suitable wheels for this package,\
+            "Can't find setup.py in this source distribution \
+             path: {:?}. This could mean there are no suitable wheels for this package, \
              and there's a problem with its setup.py.",
             setup_path
         ));
@@ -210,7 +210,7 @@ pub fn download_and_install_package(
         let mut input = String::new();
         io::stdin()
             .read_line(&mut input)
-            .expect("Unable to read user input Hash fail decision");
+            .expect("Unable to read user input hash fail decision");
 
         let input = input
             .chars()
@@ -301,7 +301,7 @@ pub fn download_and_install_package(
                             Err(e) => {
                                 // todo: dRY while troubleshooting
                                 println!(
-                                    "Problem opening the tar.gz archive: {:?}: {:?},  checking if it's a zip...",
+                                    "Problem opening the tar.gz archive: {:?}: {:?}, checking if it's a zip...",
                                     &archive_file, e
                                 );
                                 // The extract_wheel function just extracts a zip file, so it's appropriate here.
@@ -315,7 +315,7 @@ pub fn download_and_install_package(
                 }
                 Err(e) => {
                     println!(
-                        "Problem opening the tar.gz archive: {:?}: {:?},  checking if it's a zip...",
+                        "Problem opening the tar.gz archive: {:?}: {:?}, checking if it's a zip...",
                         &archive_file, e
                     );
                     // The extract_wheel function just extracts a zip file, so it's appropriate here.
@@ -327,7 +327,7 @@ pub fn download_and_install_package(
             }
 
             // The archive is now unpacked into a parent folder from the `tar.gz`. Place
-            // its sub-folders directly in the lib folder, and deleten the parent.
+            // its sub-folders directly in the lib folder, and delete the parent.
             let re = Regex::new(r"^(.*?)(?:\.tar\.gz|\.zip)$").unwrap();
             let folder_name = re
                 .captures(filename)

--- a/src/install.rs
+++ b/src/install.rs
@@ -233,7 +233,7 @@ pub fn download_and_install_package(
 
     match package_type {
         PackageType::Wheel => {
-            util::extract_zip(&archive_file, &paths.lib, &rename);
+            util::extract_zip(&archive_file, &paths.lib, &rename, &None);
         }
         PackageType::Source => {
             // todo: Support .tar.bz2
@@ -308,7 +308,7 @@ pub fn download_and_install_package(
                                 // We'll then continue with this leg, and build/move/cleanup.
 
                                 // Check if we have a zip file instead.
-                                util::extract_zip(&archive_file, &paths.lib, &None);
+                                util::extract_zip(&archive_file, &paths.lib, &None, &Some((name, filename)));
                             }
                         }
                     }
@@ -322,7 +322,7 @@ pub fn download_and_install_package(
                     // We'll then continue with this leg, and build/move/cleanup.
 
                     // Check if we have a zip file instead.
-                    util::extract_zip(&archive_file, &paths.lib, &None);
+                    util::extract_zip(&archive_file, &paths.lib, &None, &Some((name, filename)));
                 }
             }
 
@@ -465,7 +465,7 @@ pub fn download_and_install_package(
                 .expect("Problem copying wheel built from source");
 
             let file_created = fs::File::open(&moved_path).expect("Can't find created wheel.");
-            util::extract_zip(&file_created, &paths.lib, &rename);
+            util::extract_zip(&file_created, &paths.lib, &rename, &None);
 
             // Remove the created and moved wheel
             if fs::remove_file(moved_path).is_err() {
@@ -681,7 +681,7 @@ pub fn download_and_install_git(
     let archive_path = &paths.lib.join(&filename);
     let archive_file = util::open_archive(archive_path);
 
-    util::extract_zip(&archive_file, &paths.lib, &None);
+    util::extract_zip(&archive_file, &paths.lib, &None, &None);
 
     // Use the wheel's name to find the dist-info path, to avoid the chicken-egg scenario
     // of need the dist-info path to find the version.

--- a/src/util.rs
+++ b/src/util.rs
@@ -407,7 +407,12 @@ pub fn compare_names(name1: &str, name2: &str) -> bool {
 
 /// Extract the wheel or zip.
 /// From [this example](https://github.com/mvdnes/zip-rs/blob/master/examples/extract.rs#L32)
-pub fn extract_zip(file: &fs::File, out_path: &Path, rename: &Option<(String, String)>, package_names: &Option<(&str, &str)>) {
+pub fn extract_zip(
+    file: &fs::File,
+    out_path: &Path,
+    rename: &Option<(String, String)>,
+    package_names: &Option<(&str, &str)>,
+) {
     // Separate function, since we use it twice.
     let mut archive = if let Ok(a) = zip::ZipArchive::new(file) {
         a
@@ -428,7 +433,12 @@ pub fn extract_zip(file: &fs::File, out_path: &Path, rename: &Option<(String, St
         if let Some((name, filename)) = package_names {
             let stem = Path::new(filename).file_stem().unwrap();
             let components: Vec<Component> = file_str2.components().collect();
-            if components.len() == 1 || !components[0].as_os_str().to_string_lossy().starts_with(name) {
+            if components.len() == 1
+                || !components[0]
+                    .as_os_str()
+                    .to_string_lossy()
+                    .starts_with(name)
+            {
                 file_str.push(stem);
             }
         }
@@ -437,11 +447,9 @@ pub fn extract_zip(file: &fs::File, out_path: &Path, rename: &Option<(String, St
 
         let extracted_file = if !file_str.contains("dist-info") && !file_str.contains("egg-info") {
             match rename {
-                Some((old, new)) => PathBuf::from_str(
-                    file_str.to_owned()
-                        .replace(old, new)
-                        .as_str(),
-                ),
+                Some((old, new)) => {
+                    PathBuf::from_str(file_str.to_owned().replace(old, new).as_str())
+                }
                 None => PathBuf::from_str(file_str),
             }
         } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -428,18 +428,14 @@ pub fn extract_zip(file: &fs::File, out_path: &Path, rename: &Option<(String, St
         let extracted_file = if !file_str.contains("dist-info") && !file_str.contains("egg-info") {
             match rename {
                 Some((old, new)) => PathBuf::from_str(
-                    file.enclosed_name()
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                        .to_owned()
+                    file_str.to_owned()
                         .replace(old, new)
                         .as_str(),
                 ),
-                None => PathBuf::from_str(file.enclosed_name().unwrap().to_str().unwrap()),
+                None => PathBuf::from_str(file_str),
             }
         } else {
-            PathBuf::from_str(file.enclosed_name().unwrap().to_str().unwrap())
+            PathBuf::from_str(file_str)
         };
 
         let outpath = out_path.join(extracted_file.unwrap());

--- a/src/util.rs
+++ b/src/util.rs
@@ -430,6 +430,10 @@ pub fn extract_zip(
         // (which would be overwritten by this one.)
         let mut file_str = PathBuf::new();
         let file_str2 = file.enclosed_name().unwrap();
+        // The `hexdump` Python package intentionally strips its own root folder from its zip source
+        // distribution, which breaks wheel building. As a workaround, add the package name and version
+        // as a prefix to the path when extracting if the package name isn't in the first folder's
+        // name already.
         if let Some((name, filename)) = package_names {
             let stem = Path::new(filename).file_stem().unwrap();
             let components: Vec<Component> = file_str2.components().collect();

--- a/src/util.rs
+++ b/src/util.rs
@@ -428,8 +428,8 @@ pub fn extract_zip(
         let mut file = archive.by_index(i).unwrap();
         // Change name here instead of after in case we've already installed a non-renamed version.
         // (which would be overwritten by this one.)
-        let mut file_str = PathBuf::new();
         let file_str2 = file.enclosed_name().unwrap();
+        let mut file_str = PathBuf::with_capacity(file_str2.as_os_str().len());
         // The `hexdump` Python package intentionally strips its own root folder from its zip source
         // distribution, which breaks wheel building. As a workaround, add the package name and version
         // as a prefix to the path when extracting if the package name isn't in the first folder's


### PR DESCRIPTION
The package `hexdump` fails to install as it does with pip because it lacks a root folder with its archive's name (`hexdump-3.3`). This pull request gives a root folder with that naming scheme to every zip entry without a root folder starting with the name of its package, letting the wheel build and the package install. It also fixes some typos in error messages/comments.

Closes #151.

Notes:
 - I fixed (most of) the DRY with the zip detection in `download_and_install_package` by saving any error and checking if an error exists after the entire `match` statement. I do not know if that is acceptable/idiomatic Rust, but it does compile without cloning.
 - I pass both `name` and `filename` into `extract_zip` because I don't feel like parsing out the name from `filename` alone when there are variables with both right there.
 - `extract_zip` now allocates a `PathBuf` with each archive entry, but I initialize it with the capacity of the entry's length so it doesn't have to expand except during the workaround. It's also reused if no renaming is required.