### PR TITLE
Parse script dependencies in multiline `__requires__`

### DIFF
--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -29,7 +29,7 @@ pub enum SubCommand {
         packages: Vec<String>, // holds the packages names.
         /// Save package to your dev-dependencies section
         #[structopt(short, long)]
-        dev: bool
+        dev: bool,
     },
 
     /** Install packages from `pyproject.toml`, `pyflow.lock`, or specified ones. Example:

--- a/src/script.rs
+++ b/src/script.rs
@@ -199,9 +199,12 @@ fn find_deps_from_script(script: &str) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::dep_types::Version;
-    use crate::script::check_for_specified_py_vers;
+    use indoc::indoc;
     use rstest::rstest;
+
+    use crate::dep_types::Version;
+
+    use super::*;
 
     const NO_DUNDER_PYTHON: &str = r#"
 if __name__ == "__main__":
@@ -233,5 +236,83 @@ if __name__ == "__main__":
     fn dunder_python_specified(#[case] src: &str, #[case] expected: Option<Version>) {
         let result = check_for_specified_py_vers(src);
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn parse_no_dependencies_with_single_line_requires() {
+        let script = indoc! { r#"
+            __requires__ = []
+        "# };
+
+        let expected: Vec<&str> = vec![];
+        let actual = find_deps_from_script(script);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn parse_no_dependencies_with_multi_line_requires() {
+        let script = indoc! { r#"
+            __requires__ = [
+            ]
+        "# };
+
+        let expected: Vec<&str> = vec![];
+        let actual = find_deps_from_script(script);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn parse_one_dependency_with_single_line_requires() {
+        let script = indoc! { r#"
+            __requires__ = ["requests"]
+        "# };
+
+        let expected: Vec<&str> = vec!["requests"];
+        let actual = find_deps_from_script(script);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn parse_one_dependency_with_nulti_line_requires() {
+        let script = indoc! { r#"
+            __requires__ = [
+                "requests"
+            ]
+        "# };
+
+        let expected: Vec<&str> = vec!["requests"];
+        let actual = find_deps_from_script(script);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn parse_multiple_dependencies_with_single_line_requires() {
+        let script = indoc! { r#"
+            __requires__ = ["python-dateutil", "requests"]
+        "# };
+
+        let expected: Vec<&str> = vec!["python-dateutil", "requests"];
+        let actual = find_deps_from_script(script);
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn parse_multiple_dependencies_with_multi_line_requires() {
+        let script = indoc! { r#"
+            __requires__ = [
+                "python-dateutil",
+                "requests"
+            ]
+        "# };
+
+        let expected: Vec<&str> = vec!["python-dateutil", "requests"];
+        let actual = find_deps_from_script(script);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -200,42 +200,48 @@ fn find_deps_from_script(script: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
-    use rstest::rstest;
 
     use crate::dep_types::Version;
 
     use super::*;
 
-    const NO_DUNDER_PYTHON: &str = r#"
-if __name__ == "__main__":
-    print("Hello, world")
-"#;
+    #[test]
+    fn parse_python_version_no_dunder_specified() {
+        let script = indoc! { r#"
+            if __name__ == "__main__":
+                print("Hello, world")
+        "# };
 
-    const VALID_DUNDER_PYTHON: &str = r#"
-__python__ = "3.9.1"
+        let version: Option<Version> = None;
 
-if __name__ == "__main__":
-    print("Hello, world")
-"#;
+        let expected = version;
+        let actual = check_for_specified_py_vers(script);
 
-    fn py_version() -> Option<Version> {
-        let version = Version {
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn parse_python_version_valid_dunder_specified() {
+        let script = indoc! { r#"
+            __python__ = "3.9.1"
+
+            if __name__ == "__main__":
+                print("Hello, world")
+        "# };
+
+        let version: Option<Version> = Some(Version {
             major: Some(3),
             minor: Some(9),
             patch: Some(1),
             extra_num: None,
             modifier: None,
             star: false,
-        };
-        Some(version)
-    }
+        });
 
-    #[rstest]
-    #[case(NO_DUNDER_PYTHON, None)]
-    #[case(VALID_DUNDER_PYTHON, py_version())]
-    fn dunder_python_specified(#[case] src: &str, #[case] expected: Option<Version>) {
-        let result = check_for_specified_py_vers(src);
-        assert_eq!(result, expected)
+        let expected = version;
+        let actual = check_for_specified_py_vers(script);
+
+        assert_eq!(expected, actual);
     }
 
     #[test]

--- a/src/script.rs
+++ b/src/script.rs
@@ -206,7 +206,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_python_version_no_dunder_specified() {
+    fn parse_python_version_with_no_dunder_specified() {
         let script = indoc! { r#"
             if __name__ == "__main__":
                 print("Hello, world")
@@ -221,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_python_version_valid_dunder_specified() {
+    fn parse_python_version_with_valid_dunder_specified() {
         let script = indoc! { r#"
             __python__ = "3.9.1"
 
@@ -291,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_one_dependency_with_nulti_line_requires() {
+    fn parse_one_dependency_with_multi_line_requires() {
         let script = indoc! { r#"
             __requires__ = [
                 "requests"

--- a/src/script.rs
+++ b/src/script.rs
@@ -176,23 +176,23 @@ fn check_for_specified_py_vers(script: &str) -> Option<Version> {
 /// Find a script's dependencies from a variable: `__requires__ = [dep1, dep2]`
 fn find_deps_from_script(script: &str) -> Vec<String> {
     // todo: Helper for this type of logic? We use it several times in the program.
-    let re = Regex::new(r"^__requires__\s*=\s*\[(.*?)\]$").unwrap();
+    let re = Regex::new(r"(?ms)^__requires__\s*=\s*\[(.*?)\]$").unwrap();
 
     let mut result = vec![];
-    for line in script.lines() {
-        if let Some(c) = re.captures(line) {
-            let deps_list = c.get(1).unwrap().as_str().to_owned();
-            result = deps_list
-                .split(',')
-                .map(|d| {
-                    d.to_owned()
-                        .replace(" ", "")
-                        .replace("\"", "")
-                        .replace("'", "")
-                })
-                .filter(|d| !d.is_empty())
-                .collect();
-        }
+
+    if let Some(c) = re.captures(script) {
+        let deps_list = c.get(1).unwrap().as_str().to_owned();
+        result = deps_list
+            .split(',')
+            .map(|d| {
+                d.to_owned()
+                    .replace(" ", "")
+                    .replace("'", "")
+                    .replace("\"", "")
+                    .replace("\n", "")
+            })
+            .filter(|d| !d.is_empty())
+            .collect();
     }
     result
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -248,6 +248,9 @@ mod tests {
     fn parse_no_dependencies_with_single_line_requires() {
         let script = indoc! { r#"
             __requires__ = []
+
+            if __name__ == "__main__":
+                print("Hello, world")
         "# };
 
         let expected: Vec<&str> = vec![];
@@ -261,6 +264,9 @@ mod tests {
         let script = indoc! { r#"
             __requires__ = [
             ]
+
+            if __name__ == "__main__":
+                print("Hello, world")
         "# };
 
         let expected: Vec<&str> = vec![];
@@ -273,6 +279,9 @@ mod tests {
     fn parse_one_dependency_with_single_line_requires() {
         let script = indoc! { r#"
             __requires__ = ["requests"]
+
+            if __name__ == "__main__":
+                print("Hello, world")
         "# };
 
         let expected: Vec<&str> = vec!["requests"];
@@ -287,6 +296,9 @@ mod tests {
             __requires__ = [
                 "requests"
             ]
+
+            if __name__ == "__main__":
+                print("Hello, world")
         "# };
 
         let expected: Vec<&str> = vec!["requests"];
@@ -299,6 +311,9 @@ mod tests {
     fn parse_multiple_dependencies_with_single_line_requires() {
         let script = indoc! { r#"
             __requires__ = ["python-dateutil", "requests"]
+
+            if __name__ == "__main__":
+                print("Hello, world")
         "# };
 
         let expected: Vec<&str> = vec!["python-dateutil", "requests"];
@@ -314,6 +329,9 @@ mod tests {
                 "python-dateutil",
                 "requests"
             ]
+
+            if __name__ == "__main__":
+                print("Hello, world")
         "# };
 
         let expected: Vec<&str> = vec!["python-dateutil", "requests"];


### PR DESCRIPTION
Given:

```python
__requires__ = [
    "requests",
    "python-dateutil",
    ...
]
```

`pyflow` will crash, as it's unable to parse dependencies specified in a multiline statement.

This PR aims to take care of that, as well as introduce unit tests testing that logic.