### PR TITLE
Provide Python 3.10.2 for Windows

### DIFF
--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -142,7 +142,7 @@ impl PyVers {
         match self {
             Self::V3_12_0 => Version::new(3, 12, 0),
             Self::V3_11_0 => Version::new(3, 11, 0),
-            Self::V3_10_1 => Version::new(3, 10, 2),
+            Self::V3_10_2 => Version::new(3, 10, 2),
             Self::V3_9_0 => Version::new(3, 9, 0),
             Self::V3_8_0 => Version::new(3, 8, 0),
             Self::V3_7_4 => Version::new(3, 7, 4),

--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -13,10 +13,10 @@ use termcolor::Color;
 enum PyVers {
     V3_12_0, // unreleased
     V3_11_0, // unreleased
-    V3_10_0, // unreleased
+    V3_10_2, // Win
     V3_9_0,  // either Os
     V3_8_0,  // either Os
-    V3_7_4,  // Either Os
+    V3_7_4,  // either Os
     V3_6_9,  // Linux
     V3_6_8,  // Win
     V3_5_7,  // Linux
@@ -90,7 +90,11 @@ impl From<(Version, Os)> for PyVers {
                 }
             },
             10 => match v_o.1 {
-                Os::Windows | Os::Ubuntu | Os::Centos => Self::V3_10_0,
+                Os::Windows => Self::V3_10_2,
+                Os::Ubuntu | Os::Centos => {
+                    abort_helper("3.10", "Linux");
+                    unreachable!()
+                }
                 _ => {
                     abort_helper("3.10", "Mac");
                     unreachable!()
@@ -120,7 +124,7 @@ impl ToString for PyVers {
         match self {
             Self::V3_12_0 => "3.12.0".into(),
             Self::V3_11_0 => "3.11.0".into(),
-            Self::V3_10_0 => "3.10.0".into(),
+            Self::V3_10_2 => "3.10.2".into(),
             Self::V3_9_0 => "3.9.0".into(),
             Self::V3_8_0 => "3.8.0".into(),
             Self::V3_7_4 => "3.7.4".into(),
@@ -138,7 +142,7 @@ impl PyVers {
         match self {
             Self::V3_12_0 => Version::new(3, 12, 0),
             Self::V3_11_0 => Version::new(3, 11, 0),
-            Self::V3_10_0 => Version::new(3, 10, 0),
+            Self::V3_10_1 => Version::new(3, 10, 2),
             Self::V3_9_0 => Version::new(3, 9, 0),
             Self::V3_8_0 => Version::new(3, 8, 0),
             Self::V3_7_4 => Version::new(3, 7, 4),

--- a/src/py_versions.rs
+++ b/src/py_versions.rs
@@ -221,11 +221,7 @@ fn download(py_install_path: &Path, version: &Version) {
                      It's worth trying the other options, to see if one works anyway.",
                 );
                 unreachable!()
-            } //            _ => panic!("If you're seeing this, the code is in what I thought was an unreachable\
-              //            state. I could give you advice for what to do. But honestly, why should you trust me?\
-              //            I clearly screwed this up. I'm writing a message that should never appear, yet\
-              //            I know it will probably appear someday. On a deep level, I know I'm not up to this tak.\
-              //            I'm so sorry.")
+            }
         };
     }
     #[cfg(target_os = "macos")]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -417,8 +417,8 @@ pub fn unpack_tar_xz(archive_path: &Path, dest: &Path) {
     let mut decompressor = XzDecoder::new(&archive_bytes[..]);
     if decompressor.read_to_end(&mut tar).is_err() {
         abort(&format!(
-            "Problem decompressing the archive: {:?}. This may be due to a failed downoad. \
-        Try deleting it, then trying again. Note that Pyflow will only install officially-released \
+            "Problem decompressing the archive: {:?}. This may be due to a failed download. \
+        Try deleting it, then try again. Note that Pyflow will only install officially-released \
         Python versions. If you'd like to use a pre-release, you must install it manually.",
             archive_path
         ))


### PR DESCRIPTION
`python-3.10.2-windows.tar.xz` for `pybin` below. I had to abuse GitHub's upload functionality somewhat hard, but the end justifies the means.

Note: remove the `zip` extension before merging these.

[python-3.10.2-windows.tar.xz.gz.001](https://github.com/David-OConnor/pyflow/files/8228290/python-3.10.2-windows.tar.xz.gz.001.zip)
[python-3.10.2-windows.tar.xz.gz.002](https://github.com/David-OConnor/pyflow/files/8228291/python-3.10.2-windows.tar.xz.gz.002.zip)
[python-3.10.2-windows.tar.xz.gz.003](https://github.com/David-OConnor/pyflow/files/8228302/python-3.10.2-windows.tar.xz.gz.003.zip)

